### PR TITLE
#9 // fix streched icon

### DIFF
--- a/MensaBar/Views/SettingsMenuView.swift
+++ b/MensaBar/Views/SettingsMenuView.swift
@@ -23,6 +23,7 @@ struct SettingsMenuView: View {
         }
         .menuStyle(BorderlessButtonMenuStyle())
         .menuIndicator(.hidden)
+        .frame(width: 16, height: 16)
         .fixedSize()
     }
 }


### PR DESCRIPTION
Added frame size to icon to avoid stretching on certain screen sizes.

Fixes #9 